### PR TITLE
Add rerunner to reprocess failed tarballs

### DIFF
--- a/crontab
+++ b/crontab
@@ -2,3 +2,4 @@
 # (0-59)  (0-23)     (1-31)    (1-12 or Jan-Dec)  (0-6 or Sun-Sat)
 1 0 * * * /bin/bash -c "/epyc/projects/ztf-go-archivist/bin/run_archivist.sh programid1 &>> /epyc/projects/ztf-go-archivist/log/ztf-go-archivist_programid1.log"
 1 0 * * * /bin/bash -c "/epyc/projects/ztf-go-archivist/bin/run_archivist.sh programid3 &>> /epyc/projects/ztf-go-archivist/log/ztf-go-archivist_programid3.log"
+1 0 * * * /bin/bash -c "/epyc/projects/ztf-go-archivist/bin/rerun_archivist.sh &>> /epyc/projects/ztf-go-archivist/log/ztf-go-archivist_rerun.log"

--- a/rerun_archivist.sh
+++ b/rerun_archivist.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e -o pipefail
+export TZ=UTC
+
+ztf_timestamp() {
+    # Returns the ZTF-style date (YYYYMMDD) N days ago.
+    TZ=UTC echo $(date -d "$1 days ago" "+%Y%m%d")
+}
+
+ztf_tarball_path() {
+    # echoes 'yes' if a tarball exists for given timestamp and program class,
+    # else echoes 'no'.
+    #
+    # Timestamp should be ZTF-style, that is, it should be like YYYYMMDD. The
+    # program class should be 'public' or 'partnership'.
+    #
+    # Example: ztf_tarball_exists 20200526 public
+    TIMESTAMP=$1
+    PROGRAM_CLASS=$2
+    echo "/epyc/data/ztf/alerts/${PROGRAM_CLASS}/ztf_${PROGRAM_CLASS}_${TIMESTAMP}.tar.gz"
+}
+
+ztf_program_class_to_id() {
+    if [[ $1 = "public" ]]; then
+        echo "programid1"
+    else
+        echo "programid2"
+    fi
+}
+
+# When running the archivist, override the default group ID so that we start
+# from the oldest offset, regardless of any progress made.
+ZTF_ARCHIVIST_GROUP="ztf-go-archivist-rerun-$(date '+%Y%m%d')"
+export ZTF_ARCHIVIST_GROUP
+
+for DAYS_AGO in 1 2 3 4 5 6 7; do
+    TIMESTAMP=$(ztf_timestamp $DAYS_AGO)
+    for PROGRAM in public partnership; do
+        TARBALL_PATH=$(ztf_tarball_path $TIMESTAMP $PROGRAM)
+        if [ ! -f $TARBALL_PATH ]; then
+            echo "$TARBALL_PATH is missing, rerunning"
+            PROGRAM_ID=$(ztf_program_class_to_id $PROGRAM)
+            /epyc/projects/ztf-go-archivist/bin/run_archivist.sh $PROGRAM_ID $TIMESTAMP
+        fi
+    done
+done


### PR DESCRIPTION
Add a bash script which reruns the archivist if any tarballs are missing for the last 7 days. It runs for only the days that are missing. It does not deep checks or integrity checks or anything - it just notices if a tarball is _completely_ absent.

The crontab file in this repo is a lie. The actual crontab is managed by epyc's administrators, so installing this has to be done outside of source control.